### PR TITLE
SRE-2203: parse OTLP labels from ecs task

### DIFF
--- a/tools/lambda-promtail/lambda-promtail/cw.go
+++ b/tools/lambda-promtail/lambda-promtail/cw.go
@@ -3,11 +3,23 @@ package main
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/prometheus/common/model"
+)
+
+var reECSAppConfig = regexp.MustCompile(`/ecs/(?P<cloud_region>[^/]+)/(?P<deployment_environment>[^/]+)/(?P<service_name>[^/]+)-(?P<lithic_deployment_app_config>(live|sandbox|dev))`)
+var reECSNoAppConfig = regexp.MustCompile(`/ecs/(?P<cloud_region>[^/]+)/(?P<deployment_environment>[^/]+)/(?P<service_name>[^/]+)`)
+
+const (
+	LabelCloudRegion           = "cloud_region"
+	LabelDeploymentEnvironment = "deployment_environment"
+	LabelServiceName           = "service_name"
+	LabelAppConfig             = "lithic_deployment_app_config"
 )
 
 func parseCWEvent(ctx context.Context, b *batch, ev *events.CloudwatchLogsEvent) error {
@@ -24,6 +36,10 @@ func parseCWEvent(ctx context.Context, b *batch, ev *events.CloudwatchLogsEvent)
 
 	if keepStream {
 		labels[model.LabelName("__aws_cloudwatch_log_stream")] = model.LabelValue(data.LogStream)
+	}
+
+	if richLabels := parseECSTask(data.LogGroup); richLabels != nil {
+		labels.Merge(richLabels)
 	}
 
 	labels = applyExtraLabels(labels)
@@ -59,4 +75,24 @@ func processCWEvent(ctx context.Context, ev *events.CloudwatchLogsEvent) error {
 	}
 
 	return nil
+}
+
+func parseECSTask(logGroup string) model.LabelSet {
+	if !strings.HasPrefix(logGroup, "/ecs") {
+		return nil
+	}
+
+	var labels = model.LabelSet{}
+	for _, re := range []*regexp.Regexp{reECSAppConfig, reECSNoAppConfig} {
+		match := re.FindStringSubmatch(logGroup)
+		if match != nil {
+			for i, name := range re.SubexpNames() {
+				if i != 0 && name != "" {
+					labels[model.LabelName(name)] = model.LabelValue(match[i])
+				}
+			}
+			return labels
+		}
+	}
+	return labels
 }

--- a/tools/lambda-promtail/lambda-promtail/cw_test.go
+++ b/tools/lambda-promtail/lambda-promtail/cw_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+)
+
+func TestECSLogGroupParsing(t *testing.T) {
+	for taskName, expected := range logGroups {
+		t.Run(taskName, func(t *testing.T) {
+			actual := parseECSTask(taskName)
+			if !expected.Equal(actual) {
+				t.Errorf("actual != expected. Actual: %s. Expected %s", actual.String(), expected.String())
+				t.Fail()
+			}
+		})
+	}
+}
+
+// This is a subset of the log groups I found in production by running the following loki query:
+// sum by(cloudwatch_log_group, cloudwatch_owner)(rate({cloudwatch_log_group=~".+"} [15m]))
+var logGroups = map[string]model.LabelSet{
+	// These should not parse and should return an empty label set
+	"/aws/amazonmq/broker/b-7144cd02-e9b3-4209-b89d-8c19074b6290/connection": {},
+	"/networking/twingate/us-west-1-segshare-prod":                           {},
+	"RDSOSMetrics": {},
+
+	// These should parse with the app config label
+	"/ecs/us-west-1/prod/acs-bridge-live": {
+		model.LabelName(LabelCloudRegion):           model.LabelValue("us-west-1"),
+		model.LabelName(LabelDeploymentEnvironment): model.LabelValue("prod"),
+		model.LabelName(LabelServiceName):           model.LabelValue("acs-bridge"),
+		model.LabelName(LabelAppConfig):             model.LabelValue("live"),
+	},
+	"/ecs/us-west-1/prod/asa-proxy-sandbox": {
+		model.LabelName(LabelCloudRegion):           model.LabelValue("us-west-1"),
+		model.LabelName(LabelDeploymentEnvironment): model.LabelValue("prod"),
+		model.LabelName(LabelServiceName):           model.LabelValue("asa-proxy"),
+		model.LabelName(LabelAppConfig):             model.LabelValue("sandbox"),
+	},
+	"/ecs/us-west-1/staging/acs-bridge-live": {
+		model.LabelName(LabelCloudRegion):           model.LabelValue("us-west-1"),
+		model.LabelName(LabelDeploymentEnvironment): model.LabelValue("staging"),
+		model.LabelName(LabelServiceName):           model.LabelValue("acs-bridge"),
+		model.LabelName(LabelAppConfig):             model.LabelValue("live"),
+	},
+	"/ecs/us-west-1/staging/asa-proxy-sandbox": {
+		model.LabelName(LabelCloudRegion):           model.LabelValue("us-west-1"),
+		model.LabelName(LabelDeploymentEnvironment): model.LabelValue("staging"),
+		model.LabelName(LabelServiceName):           model.LabelValue("asa-proxy"),
+		model.LabelName(LabelAppConfig):             model.LabelValue("sandbox"),
+	},
+	"/ecs/us-west-2/dev/iso-bridge-dev": {
+		model.LabelName(LabelCloudRegion):           model.LabelValue("us-west-2"),
+		model.LabelName(LabelDeploymentEnvironment): model.LabelValue("dev"),
+		model.LabelName(LabelServiceName):           model.LabelValue("iso-bridge"),
+		model.LabelName(LabelAppConfig):             model.LabelValue("dev"),
+	},
+
+	// These should parse without the app config label
+	"/ecs/us-west-1/prod/visa-bridge-1": {
+		model.LabelName(LabelCloudRegion):           model.LabelValue("us-west-1"),
+		model.LabelName(LabelDeploymentEnvironment): model.LabelValue("prod"),
+		model.LabelName(LabelServiceName):           model.LabelValue("visa-bridge-1"),
+	},
+	"/ecs/us-west-1/staging/grafana-agent-collector": {
+		model.LabelName(LabelCloudRegion):           model.LabelValue("us-west-1"),
+		model.LabelName(LabelDeploymentEnvironment): model.LabelValue("staging"),
+		model.LabelName(LabelServiceName):           model.LabelValue("grafana-agent-collector"),
+	},
+	"/ecs/us-west-1/staging/mastercard-bridge": {
+		model.LabelName(LabelCloudRegion):           model.LabelValue("us-west-1"),
+		model.LabelName(LabelDeploymentEnvironment): model.LabelValue("staging"),
+		model.LabelName(LabelServiceName):           model.LabelValue("mastercard-bridge"),
+	},
+	"/ecs/us-west-1/staging/pwp-proxy": {
+		model.LabelName(LabelCloudRegion):           model.LabelValue("us-west-1"),
+		model.LabelName(LabelDeploymentEnvironment): model.LabelValue("staging"),
+		model.LabelName(LabelServiceName):           model.LabelValue("pwp-proxy"),
+	},
+	"/ecs/us-west-2/prod/fml": {
+		model.LabelName(LabelCloudRegion):           model.LabelValue("us-west-2"),
+		model.LabelName(LabelDeploymentEnvironment): model.LabelValue("prod"),
+		model.LabelName(LabelServiceName):           model.LabelValue("fml"),
+	},
+}


### PR DESCRIPTION
This creates two regexp statements to parse out the basic OTLP labels from the log group names. If the parsing fails then nothing happens. If and when it passes then the logs associated with these log groups will have the following labels:

1. service_name - maps to service.name in traces
2. deployment_environment - maps to deployment.environment in traces
3. cloud_region - maps to cloud.region in traces
4. lithic_deployment_app_config - maps to lithic.deployment.app_config in traces

This enables us to correlate logs/metrics/traces from the Application dashboard in Grafana.

I grabbed all cw log groups from [here](https://lithic.grafana.net/goto/NFAYgNDIg?orgId=1) and added a unique set of them to the go test. Below are the results of `go test`.


```
- [:bjones/SRE-2203/parse-otlp-labels-from-ecs-task] loki/tools/lambda-promtail/lambda-promtail/ $ go test ./... -v
=== RUN   TestECSLogGroupParsing
=== RUN   TestECSLogGroupParsing//aws/amazonmq/broker/b-7144cd02-e9b3-4209-b89d-8c19074b6290/connection
=== RUN   TestECSLogGroupParsing/RDSOSMetrics
=== RUN   TestECSLogGroupParsing//ecs/us-west-1/staging/acs-bridge-live
=== RUN   TestECSLogGroupParsing//networking/twingate/us-west-1-segshare-prod
=== RUN   TestECSLogGroupParsing//ecs/us-west-1/prod/acs-bridge-live
=== RUN   TestECSLogGroupParsing//ecs/us-west-1/prod/asa-proxy-sandbox
=== RUN   TestECSLogGroupParsing//ecs/us-west-1/staging/asa-proxy-sandbox
=== RUN   TestECSLogGroupParsing//ecs/us-west-2/dev/iso-bridge-dev
=== RUN   TestECSLogGroupParsing//ecs/us-west-1/prod/visa-bridge-1
=== RUN   TestECSLogGroupParsing//ecs/us-west-1/staging/grafana-agent-collector
=== RUN   TestECSLogGroupParsing//ecs/us-west-1/staging/mastercard-bridge
=== RUN   TestECSLogGroupParsing//ecs/us-west-1/staging/pwp-proxy
=== RUN   TestECSLogGroupParsing//ecs/us-west-2/prod/fml
--- PASS: TestECSLogGroupParsing (0.00s)
    --- PASS: TestECSLogGroupParsing//aws/amazonmq/broker/b-7144cd02-e9b3-4209-b89d-8c19074b6290/connection (0.00s)
    --- PASS: TestECSLogGroupParsing/RDSOSMetrics (0.00s)
    --- PASS: TestECSLogGroupParsing//ecs/us-west-1/staging/acs-bridge-live (0.00s)
    --- PASS: TestECSLogGroupParsing//networking/twingate/us-west-1-segshare-prod (0.00s)
    --- PASS: TestECSLogGroupParsing//ecs/us-west-1/prod/acs-bridge-live (0.00s)
    --- PASS: TestECSLogGroupParsing//ecs/us-west-1/prod/asa-proxy-sandbox (0.00s)
    --- PASS: TestECSLogGroupParsing//ecs/us-west-1/staging/asa-proxy-sandbox (0.00s)
    --- PASS: TestECSLogGroupParsing//ecs/us-west-2/dev/iso-bridge-dev (0.00s)
    --- PASS: TestECSLogGroupParsing//ecs/us-west-1/prod/visa-bridge-1 (0.00s)
    --- PASS: TestECSLogGroupParsing//ecs/us-west-1/staging/grafana-agent-collector (0.00s)
    --- PASS: TestECSLogGroupParsing//ecs/us-west-1/staging/mastercard-bridge (0.00s)
    --- PASS: TestECSLogGroupParsing//ecs/us-west-1/staging/pwp-proxy (0.00s)
    --- PASS: TestECSLogGroupParsing//ecs/us-west-2/prod/fml (0.00s)
=== RUN   TestLambdaPromtail_KinesisParseEvents
--- PASS: TestLambdaPromtail_KinesisParseEvents (0.00s)
=== RUN   TestLambdaPromtail_ExtraLabelsValid
extra labels: {__extra_A1="a", __extra_B2="b", __extra_C3="c", __extra_D4="d"}
--- PASS: TestLambdaPromtail_ExtraLabelsValid (0.00s)
=== RUN   TestLambdaPromtail_ExtraLabelsMissingValue
--- PASS: TestLambdaPromtail_ExtraLabelsMissingValue (0.00s)
=== RUN   TestLambdaPromtail_ExtraLabelsInvalidNames
--- PASS: TestLambdaPromtail_ExtraLabelsInvalidNames (0.00s)
=== RUN   TestLambdaPromtail_TestParseLabelsNoneProvided
--- PASS: TestLambdaPromtail_TestParseLabelsNoneProvided (0.00s)
PASS
ok      main/lambda-promtail    0.007s
```



